### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,4 @@ Takes an image and stores it as a face template into a gallery you define
 
 ## References
 Thank you to gregmoreno for creating this api template - https://github.com/gregmoreno/awesome
+Test on [RapidAPI](https://rapidapi.com/package/KairosAPI/functions?utm_source=KairosGitHub&utm_medium=button)


### PR DESCRIPTION
I've added a link in your README to Kairos's functions page in RapidAPI. I've done this for a few Kairos SDKs to help those who are reading the READMEs, understand and test the API before use.